### PR TITLE
App2App for iframes (launch & message)

### DIFF
--- a/interface/src/index.d.ts
+++ b/interface/src/index.d.ts
@@ -40,6 +40,7 @@ declare namespace ZLUX {
     makeAction(id: string, defaultName: string, targetMode: ActionTargetMode, type: ActionType, targetPluginID: string, primaryArgument: any): Action;
     registerApplicationCallbacks(plugin: Plugin, applicationInstanceId: any, callbacks: ApplicationCallbacks): void;
     clear(): void;
+    iframeLoaded(instanceId: MVDHosting.InstanceId, identifier: string);
     constants: DispatcherConstants;
   }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 0"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Solved various issues:
- echo test was not discriminating on what was and wasnt iframe, leading to exceptions
- postmessage needed for iframe app2app was never called for message or launch

Needed to implement:
- iframes take time to load, and without knowledge of the iframes in the app framework, iframes need to inform the framework of when they have loaded so that any launch context can be provided only after they are ready. To do this, the info to be sent is cached until the iframe is ready.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>