### PR TITLE
Fix for logout not updating references properly

### DIFF
--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -97,6 +97,23 @@ export class Dispatcher implements ZLUX.Dispatcher {
    static dispatcherHeartbeatInterval:number = 60000; /* one minute */
 
    clear(): void {
+     let typesIt = this.instancesForTypes.keys();
+     let type = typesIt.next();
+     while (!type.done) {
+       let plugin = type.value;
+       let instancesArray = this.instancesForTypes.get(plugin) || [];
+       for (let j = 0; j < instancesArray.length; j++) {
+         let instance = instancesArray[j];
+         let watchers = this.pluginWatchers.get(plugin);
+         if (watchers) {
+           for (let k = 0; k < watchers.length; k++) {
+             watchers[k].instanceRemoved(instance.applicationInstanceId);
+           }
+         }
+         return;
+       }
+       type = typesIt.next();
+     }
     this.instancesForTypes.clear();
     this.indexedRecognizers.clear();
     this.recognizers = [];


### PR DESCRIPTION
instanceRemoved was never called on logout due to clear function not informing watchers of the clearing. This was apparent for the launchbar icon snapshot logic which altered its array based on listening for instanceRemoved

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>