### PR TITLE
Added requestWindowFocus method to interface

### DIFF
--- a/interface/src/mvd-window-management.d.ts
+++ b/interface/src/mvd-window-management.d.ts
@@ -25,6 +25,7 @@ declare namespace MVDWindowManagement {
     showWindow(windowId: MVDWindowManagement.WindowId): void;
     closeWindow(windowId: MVDWindowManagement.WindowId): void;
     closeAllWindows():void;
+    requestWindowFocus(windowId: MVDWindowManagement.WindowId): boolean;
   }
 }
 


### PR DESCRIPTION
Fixes Iframes not focusing on inner body click by using the requestWindowFocus method instead.

**PR 2/2**
1. https://github.com/zowe/zlux-app-manager/pull/145
2. This