### PR TITLE
Recognizer capabilities

### DIFF
--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -212,7 +212,32 @@ export class Dispatcher implements ZLUX.Dispatcher {
      }
    }
 
+   getRecognizersForCapabilities(capabilities: string[], tuple: any) {
+     const recognizersForCapabilities: RecognitionRule[] = this.getRecognizersForCapabilitiesInternal(capabilities);
+
+     return this.getRecognizersInternal(recognizersForCapabilities, tuple);
+   }
+
+   getRecognizersForCapabilitiesInternal(capabilities: string[]):RecognitionRule[] {
+     if (!capabilities || capabilities.length === 0) {
+       return this.recognizers;
+     } else {
+       return this.recognizers.filter( (recognizer: RecognitionRule) => {
+         const recognizerCapabilities: string[] = recognizer.capabilities;
+         if (recognizerCapabilities) {
+           return capabilities.some(capability => recognizerCapabilities.indexOf(capability) >= 0)
+         } else {
+           return false;
+         }
+       });
+     }
+   }
+
    getRecognizers(tuple:any):RecognitionRule[] {
+     return this.getRecognizersInternal(this.recognizers, tuple);
+   }
+
+   getRecognizersInternal(recognizerSet: RecognitionRule[], tuple: any):RecognitionRule[] {
      let matchedRecognizers:any[] = [];
      // we can get the set of recognizers that match on this property at top clause
      // and those that don't, too.
@@ -241,7 +266,7 @@ export class Dispatcher implements ZLUX.Dispatcher {
          return matchedRecognizers;  // since we had an index, good enough
        }
      } 
-     this.recognizers.forEach( (recognizer:RecognitionRule) => {
+     recognizerSet.forEach( (recognizer:RecognitionRule) => {
        if (recognizer.predicate.match(tuple)){
          matchedRecognizers.push(recognizer);
        }
@@ -579,6 +604,8 @@ export class Dispatcher implements ZLUX.Dispatcher {
 export class RecognitionRule {
   predicate:RecognitionClause;
   actionID:string;
+  capabilities: string[];
+  originatingPluginID: string;
 
   constructor(predicate:RecognitionClause, actionID:string){
     this.predicate = predicate;

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -492,8 +492,13 @@ export class Dispatcher implements ZLUX.Dispatcher {
      }
    }
 
+   isEmpty(obj: any): boolean {
+     const isEmptyObj: boolean = (!obj) || (Object.keys(obj).length == 0);
+     return isEmptyObj;
+   }
+
    buildObjectFromTemplate(template:any, eventContext:any):any{
-      if (!template) {
+      if (!template || this.isEmpty(template)) {
         this.log.debug('no template provided, returning argument "as is"', eventContext);
         return eventContext;
       }
@@ -962,34 +967,54 @@ export enum ActionType {       // not all actions are meaningful for all target 
 } 
   
 
-export class Action implements ZLUX.Action {
+export class AbstractAction implements ZLUX.AbstractAction {
     id: string;           // id of action itself.
     i18nNameKey: string;  // future proofing for I18N
     defaultName: string;  // default name for display purposes, w/o I18N
     description: string;
-    targetMode: ActionTargetMode;
-    type: ActionType;   // "launch", "message"
-    targetPluginID: string;
-    primaryArgument: any;
 
     constructor(id: string, 
-                defaultName: string,
-                targetMode: ActionTargetMode, 
-                type: ActionType,
-                targetPluginID: string,
-                primaryArgument:any) {
+                defaultName: string) {
        this.id = id;
        this.defaultName = defaultName;
        // proper name for ID/tye
-       this.targetPluginID = targetPluginID; 
-       this.targetMode = targetMode;
-       this.type = type;
-       this.primaryArgument = primaryArgument;
     }
 
     getDefaultName():string {
       return this.defaultName;
     }
+
+    getId(): string {
+      return this.id;
+    }
+}
+
+export class Action extends AbstractAction implements ZLUX.Action {
+  targetMode: ActionTargetMode;
+  type: ActionType;   // "launch", "message"
+  targetPluginID: string;
+  primaryArgument?: any;
+
+  constructor(id: string,
+              defaultName: string,
+              targetMode: ActionTargetMode,
+              type: ActionType,
+              targetPluginID: string,
+              primaryArgument?: any) {
+    super(id, defaultName);
+    this.targetPluginID = targetPluginID;
+    this.targetMode = targetMode;
+    this.type = type;
+    this.primaryArgument = primaryArgument;
+  }
+}
+
+export class Actioncontainer extends AbstractAction implements ZLUX.ActionContainer {
+  children: ZLUX.AbstractAction[];
+
+  getChildren(): ZLUX.AbstractAction[] {
+    return this.children
+  }
 }
 
 

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -493,6 +493,11 @@ export class Dispatcher implements ZLUX.Dispatcher {
    }
 
    buildObjectFromTemplate(template:any, eventContext:any):any{
+      if (!template) {
+        this.log.debug('no template provided, returning argument "as is"', eventContext);
+        return eventContext;
+      }
+
       let outputObject:any = Array.isArray(template) ? [] : {};
       let dispatcher:Dispatcher = this;
       for (let propName in template){

--- a/interface/src/index.d.ts
+++ b/interface/src/index.d.ts
@@ -107,8 +107,20 @@ declare namespace ZLUX {
     ActionType: any
   }
 
-  interface Action {
+  interface AbstractAction {
+    getId(): string;
     getDefaultName(): string;
+  }
+
+  interface Action extends AbstractAction {
+  }
+
+  interface ActionReference {
+    targetActionId: string;
+  }
+
+  interface ActionContainer extends AbstractAction {
+    getChildren(): (AbstractAction | ActionReference)[];
   }
 
   interface ComponentLogger {

--- a/interface/src/index.d.ts
+++ b/interface/src/index.d.ts
@@ -33,7 +33,8 @@ declare namespace ZLUX {
     setPostMessageHandler(postMessageCallback: any): void;
     getRecognizers(tuple: any): RecognitionRule[];
     getRecognizersForCapabilities(capabilities: string[], tuple: any): RecognitionRule[];
-    addRecognizerFromObject(predicateObject:RecognitionObjectPropClause | RecognitionObjectOpClause, actionID:string):void;
+    addRecognizerFromObject(predicateObject:RecognitionObjectPropClause | RecognitionObjectOpClause, actionID:string, capabilities?: string[]):void;
+    addRecognizerObject(recoginzerObject: ZLUX.RecognizerObject): void;
     addRecognizer(predicate: RecognitionClause, actionID: string): void;
     registerAction(action: Action): void;
     getAction(recognizer: any): Action | undefined;
@@ -47,6 +48,7 @@ declare namespace ZLUX {
 
   type RecognizerObject = {
     id: string,
+    capabilities?: string[],
     clause: RecognitionObjectPropClause | RecognitionObjectOpClause
   }
 

--- a/interface/src/index.d.ts
+++ b/interface/src/index.d.ts
@@ -31,13 +31,25 @@ declare namespace ZLUX {
     deregisterPluginInstance(plugin: Plugin, applicationInstanceId: any): void;
     setLaunchHandler(launchCallback: any): void;
     setPostMessageHandler(postMessageCallback: any): void;
-    getRecognizers(tuple: any): RecognitionRule[];
-    getRecognizersForCapabilities(capabilities: string[], tuple: any): RecognitionRule[];
+    /**
+    * @deprecated Use getActions instead
+    * @see getActions
+    * @param applicationContext 
+    */
+    getRecognizers(applicationContext: any): RecognitionRule[];
+    /**
+     * @deprecated Use addRecognizerObject instead
+     * @see addRecognizerObject
+     * @param predicateObject 
+     * @param actionID 
+     * @param capabilities 
+     */
     addRecognizerFromObject(predicateObject:RecognitionObjectPropClause | RecognitionObjectOpClause, actionID:string, capabilities?: string[]):void;
     addRecognizerObject(recoginzerObject: ZLUX.RecognizerObject): void;
     addRecognizer(predicate: RecognitionClause, actionID: string): void;
-    registerAction(action: Action): void;
+    registerAction(action: AbstractAction): void;
     getAction(recognizer: any): Action | undefined;
+    getActions(capabilities: string[], applicationContext: any): ActionLookupResult;
     addPendingIframe(plugin:ZLUX.Plugin, launchMetadata: any): void;
     callInstance(eventName: string, appInstanceId:string, data: Object): Promise<any>;
     callAny(eventName: string, pluginId:string, data: Object): Promise<any>;
@@ -46,7 +58,8 @@ declare namespace ZLUX {
     registerEventListener(eventName: string, callback: EventListenerOrEventListenerObject | null, appId: string): void;
     deregisterEventListener(eventName: string, callback: EventListenerOrEventListenerObject | null, appId: string, pluginId:string): void;
     invokeAction(action: Action, eventContext: any, targetId?: number): any;
-    makeAction(id: string, defaultName: string, targetMode: ActionTargetMode, type: ActionType, targetPluginID: string, primaryArgument: any): Action;
+    makeAction(id: string, defaultName: string, targetMode: ActionTargetMode, type: ActionType, targetPluginID: string, primaryArgument: any): AbstractAction;
+    makeActionFromObject(action: AbstractAction): AbstractAction;
     registerApplicationCallbacks(plugin: Plugin, applicationInstanceId: any, callbacks: ApplicationCallbacks): void;
     clear(): void;
     iframeLoaded(instanceId: MVDHosting.InstanceId, identifier: string);
@@ -108,8 +121,18 @@ declare namespace ZLUX {
   }
 
   interface AbstractAction {
+    /**
+     * null implies "Action" for backwards-compatibility
+     */
+    objectType?: ActionObjectType;
+    id: string;
+    defaultName: string;
     getId(): string;
     getDefaultName(): string;
+  }
+
+  enum ActionObjectType {
+    Action, ActionContainer
   }
 
   interface Action extends AbstractAction {
@@ -120,7 +143,19 @@ declare namespace ZLUX {
   }
 
   interface ActionContainer extends AbstractAction {
+    children: (AbstractAction | ActionReference)[];
     getChildren(): (AbstractAction | ActionReference)[];
+  }
+
+  interface ActionLookupResult {
+    actions?: AbstractAction[];
+    unresolvedActionIds?: string[];
+  }
+
+  interface DispatchMetaData  {
+    originatingActionId: string;
+    originaltingAppInstanceId: string;
+    applicationContext: any;
   }
 
   interface ComponentLogger {

--- a/interface/src/index.d.ts
+++ b/interface/src/index.d.ts
@@ -47,9 +47,11 @@ declare namespace ZLUX {
     addRecognizerFromObject(predicateObject:RecognitionObjectPropClause | RecognitionObjectOpClause, actionID:string, capabilities?: string[]):void;
     addRecognizerObject(recoginzerObject: ZLUX.RecognizerObject): void;
     addRecognizer(predicate: RecognitionClause, actionID: string): void;
-    registerAction(action: AbstractAction): void;
+    registerAction(action: Action): void;
     getAction(recognizer: any): Action | undefined;
-    getActions(capabilities: string[], applicationContext: any): ActionLookupResult;
+    registerAbstractAction(action: AbstractAction): void;
+    getAbstractActionById(actionId: string): AbstractAction | undefined;
+    getAbstractActions(capabilities: string[], applicationContext: any): ActionLookupResult;
     addPendingIframe(plugin:ZLUX.Plugin, launchMetadata: any): void;
     callInstance(eventName: string, appInstanceId:string, data: Object): Promise<any>;
     callAny(eventName: string, pluginId:string, data: Object): Promise<any>;
@@ -58,7 +60,7 @@ declare namespace ZLUX {
     registerEventListener(eventName: string, callback: EventListenerOrEventListenerObject | null, appId: string): void;
     deregisterEventListener(eventName: string, callback: EventListenerOrEventListenerObject | null, appId: string, pluginId:string): void;
     invokeAction(action: Action, eventContext: any, targetId?: number): any;
-    makeAction(id: string, defaultName: string, targetMode: ActionTargetMode, type: ActionType, targetPluginID: string, primaryArgument: any): AbstractAction;
+    makeAction(id: string, defaultName: string, targetMode: ActionTargetMode, type: ActionType, targetPluginID: string, primaryArgument: any): Action;
     makeActionFromObject(action: AbstractAction): AbstractAction;
     registerApplicationCallbacks(plugin: Plugin, applicationInstanceId: any, callbacks: ApplicationCallbacks): void;
     clear(): void;
@@ -136,6 +138,9 @@ declare namespace ZLUX {
   }
 
   interface Action extends AbstractAction {
+    targetPluginID: string;
+    type: ActionType;
+    targetMode: ActionTargetMode;
   }
 
   interface ActionReference {

--- a/interface/src/index.d.ts
+++ b/interface/src/index.d.ts
@@ -32,6 +32,7 @@ declare namespace ZLUX {
     setLaunchHandler(launchCallback: any): void;
     setPostMessageHandler(postMessageCallback: any): void;
     getRecognizers(tuple: any): RecognitionRule[];
+    getRecognizersForCapabilities(capabilities: string[], tuple: any): RecognitionRule[];
     addRecognizerFromObject(predicateObject:RecognitionObjectPropClause | RecognitionObjectOpClause, actionID:string):void;
     addRecognizer(predicate: RecognitionClause, actionID: string): void;
     registerAction(action: Action): void;


### PR DESCRIPTION
Enhancements to the Actions/Recognizer APIs

required for https://github.com/zowe/zlux-app-manager/pull/160

- concept of "capabilities" (currently declared in the Recognizers, but maybe it makes more sense to have in the Actions?
- ability to "nest" Actions
  - the "nesting" is really a "request" from the developer of the Action. Ideally the consumer of the action(s) will honor the nesting "request" with cascading menus or trees. The "actual actions" must still all have unique ids.
  - an ActionContainer can contain a mixture of Action and ActionReference in the children. This can allow an Action to be reused in a different context.
- ability to skip over the recognizers and get the relevant actions in just one call
- change "tuple" to "applicationContext" for more readable declarations