### PR TITLE
Exposed setters for language and locale for iframe adapter testing

### DIFF
--- a/interface/src/index.d.ts
+++ b/interface/src/index.d.ts
@@ -125,6 +125,8 @@ declare namespace ZLUX {
   interface Globalization {
     getLanguage(): string;
     getLocale(): string;
+    setLanguage(language: string): Promise<any>;
+    setLocale(locale: string): Promise<any>;
   }
 
   type UnixFileUriOptions = {

--- a/interface/src/index.d.ts
+++ b/interface/src/index.d.ts
@@ -125,8 +125,8 @@ declare namespace ZLUX {
   interface Globalization {
     getLanguage(): string;
     getLocale(): string;
-    setLanguage(language: string): Promise<any>;
-    setLocale(locale: string): Promise<any>;
+    setLanguage(language: string): any;
+    setLocale(locale: string): any;
   }
 
   type UnixFileUriOptions = {


### PR DESCRIPTION
The DCO check for this fails due to the SimpleGlobalization class which is resolved in this PR:
https://github.com/zowe/zlux-app-manager/pull/168

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>