### PR TITLE
Request window focus on app2app when there is an instance Id to attempt

### DIFF
--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -805,6 +805,11 @@ export class Dispatcher implements ZLUX.Dispatcher {
                                      dispatchData: eventContext
                                    });
         }
+        if (targetId && this.windowManager) {
+          this.windowManager.focus(targetId);
+        } else if (this.windowManager) {
+          this.windowManager.focus(wrapper.applicationInstanceId);
+        }
         break;
       case ActionType.Minimize:
           if (targetId && this.windowManager) {


### PR DESCRIPTION
Makes use of https://github.com/zowe/zlux-app-manager/pull/188
Basically, when requesting an app it should become focused, if we know which app it was. Prior: when an app was called, it would remain where it was, so you may not see that it did anything.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>