### PR TITLE
Added token for theme emitter

### DIFF
--- a/interface/src/mvd-hosting.d.ts
+++ b/interface/src/mvd-hosting.d.ts
@@ -18,7 +18,8 @@ declare namespace MVDHosting {
     ApplicationManagerToken = "com.rs.mvd.hosting.application-manager",
     ViewportManagerToken = "com.rs.mvd.hosting.viewport-manager",
     PluginManagerToken = "com.rs.mvd.hosting.plugin-manager",
-    AuthenticationManagerToken = "com.rs.mvd.hosting.authentication-manager"
+    AuthenticationManagerToken = "com.rs.mvd.hosting.authentication-manager",
+    ThemeEmitterToken = "com.rs.mvd.hosting.theme-emitter"
   }
 
   export const enum ZoweNotificationType {


### PR DESCRIPTION
- So theme emitter can be used in authentication manager for login timeout prompt

PR 2 of 2
1/2: https://github.com/zowe/zlux-app-manager/pull/221

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>