### PR TITLE
dispatcher.invokeAction must return promise

### DIFF
--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -784,9 +784,9 @@ export class Dispatcher implements ZLUX.Dispatcher {
     }
   }
 
-  invokeAction(action:Action, eventContext: any, targetId?: number):any{
+  invokeAction(action:Action, eventContext: any, targetId?: number): Promise<void> {
     this.log.info("ZWED5042I", JSON.stringify(eventContext)); //this.log.info("dispatcher.invokeAction on context "+JSON.stringify(eventContext));
-    this.getActionTarget(action,eventContext).then( (target: ActionTarget) => {
+    return this.getActionTarget(action,eventContext).then( (target: ActionTarget) => {
       const wrapper = target.wrapper; 
       switch (action.type) {
       case ActionType.Launch:

--- a/interface/src/index.d.ts
+++ b/interface/src/index.d.ts
@@ -59,7 +59,7 @@ declare namespace ZLUX {
     callEveryone(eventName: string, data: Object, failOnError: boolean): Promise<any>;
     registerEventListener(eventName: string, callback: EventListenerOrEventListenerObject | null, appId: string): void;
     deregisterEventListener(eventName: string, callback: EventListenerOrEventListenerObject | null, appId: string, pluginId:string): void;
-    invokeAction(action: Action, eventContext: any, targetId?: number): any;
+    invokeAction(action: Action, eventContext: any, targetId?: number): Promise<void>;
     makeAction(id: string, defaultName: string, targetMode: ActionTargetMode, type: ActionType, targetPluginID: string, primaryArgument: any): Action;
     makeActionFromObject(action: AbstractAction): AbstractAction;
     registerApplicationCallbacks(plugin: Plugin, applicationInstanceId: any, callbacks: ApplicationCallbacks): void;


### PR DESCRIPTION
In order to provide ability to wait until `dispatcher.invokeAction` finishes and to handle errors the `dispatcher.invokeAction` method must return a promise.
