### PR TITLE
Add 'not equal', 'less than', and 'greater than' recognition operator

### DIFF
--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -351,11 +351,6 @@ export class Dispatcher implements ZLUX.Dispatcher {
     } else if ((<ZLUX.RecognitionObjectPropClause>predicateObject).prop && ((<ZLUX.RecognitionObjectPropClause>predicateObject).prop.length >= 2)) {
       const predicateProp: ZLUX.RecognitionObjectPropClause = <ZLUX.RecognitionObjectPropClause> predicateObject;
       return new RecognizerProperty(...predicateProp.prop);
-      // if ((<ZLUX.RecognitionObjectPropClause>predicateObject).prop.length == 2){
-      //   return new RecognizerProperty(predicateProp.prop[0],predicateProp.prop[1]);
-      // } else {
-      //   return new RecognizerProperty(predicateProp.prop[0],predicateProp.prop[1], predicateProp.prop[2]);
-      // }
     } else {
       throw new Error('ZWED5022E - Error in recognizer definition');
     }

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -330,6 +330,13 @@ export class Dispatcher implements ZLUX.Dispatcher {
     if ((<ZLUX.RecognitionObjectOpClause>predicateObject).op) {
       const predicateOp: ZLUX.RecognitionObjectOpClause = <ZLUX.RecognitionObjectOpClause>predicateObject
       switch (predicateOp.op) {
+      case 'NOT':
+        if(predicateOp.args && predicateOp.args.length != 1){
+          const predicateProp: ZLUX.RecognitionObjectPropClause = <ZLUX.RecognitionObjectPropClause> (predicateOp.args as any)[0].prop;
+          return new RecognizerNot(predicateProp.prop[0],predicateProp.prop[1]);
+        } else {
+          throw new Error(`ZWED5020E - NOT is a unary recognizer op and only requires one arg.`);
+        }
       case 'AND':
       case 'OR':
         if (predicateOp.args) {

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -368,7 +368,7 @@ export class Dispatcher implements ZLUX.Dispatcher {
      this.recognizers.push(recognitionRule);
      if (predicate.operation == RecognitionOp.AND){
        for (let subClause of predicate.subClauses){
-         if ((subClause as RecognitionClause).operation == RecognitionOp.PROPERTY_EQ || (subClause as RecognitionClause).operation == RecognitionOp.NOT){
+         if ((subClause as RecognitionClause).operation == RecognitionOp.PROPERTY_EQ){
            let propertyClause:RecognitionClause = subClause as RecognitionClause;
            let propertyName:string = propertyClause.subClauses[0] as string;
            let propertyValue:string|number = propertyClause.subClauses[1] as string|number;

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -330,7 +330,6 @@ export class Dispatcher implements ZLUX.Dispatcher {
     if ((<ZLUX.RecognitionObjectOpClause>predicateObject).op) {
       const predicateOp: ZLUX.RecognitionObjectOpClause = <ZLUX.RecognitionObjectOpClause>predicateObject
       switch (predicateOp.op) {
-      case 'NOT':
       case 'AND':
       case 'OR':
         if (predicateOp.args) {
@@ -671,7 +670,6 @@ export class Dispatcher implements ZLUX.Dispatcher {
         if (!targetPluginID) {
           targetPluginID = actionAsAny.targetId;
         }
-        console.log("returning new action");
         return new Action(id, defaultName, targetMode, type, targetPluginID, primaryArgument);
     }
 

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -1055,6 +1055,8 @@ export enum RecognitionOp {
   NOT,
   PROPERTY_EQ,        
   PROPERTY_NE,
+  PROPERTY_LT,
+  PROPERTY_GT ,
   SOURCE_PLUGIN_TYPE,      // syntactic sugar
   MIME_TYPE,        // ditto
 }
@@ -1108,23 +1110,29 @@ type PropertyName = string | string[];
 
 export class RecognizerProperty extends RecognitionClause {
   constructor(...args:(RecognitionClause|number|string|string[])[]){
-    switch(args.length){
-      case 3:
+    if(args.length == 3){
         const op = args[0] as string;
-        if (op === 'NE') {
-          super(RecognitionOp.PROPERTY_NE);
-        } else if (op === 'EQ') {
-          super(RecognitionOp.PROPERTY_EQ);
-        }else {
-          throw new Error(`ZWED5023E - Unknown operator '${op}' in recognition clause ${JSON.stringify(args)})`);
+        switch (op) {
+          case 'NE':
+            super(RecognitionOp.PROPERTY_NE);
+            break;
+          case 'LT':
+            super(RecognitionOp.PROPERTY_LT);
+            break;
+          case 'GT':
+            super(RecognitionOp.PROPERTY_GT);
+            break;
+          case 'EQ':
+            super(RecognitionOp.PROPERTY_EQ);
+            break;
+          default:
+            super(RecognitionOp.PROPERTY_EQ);
+            throw new Error(`ZWED5023E - Unknown operator '${op}' in recognition clause ${JSON.stringify(args)})`);
         }
         args.shift(); // omit operator
-        break;
-      case 2:
-      default:
+      } else {
         super(RecognitionOp.PROPERTY_EQ);
-        break;
-    }
+      }
     this.subClauses = args;
   }
 
@@ -1135,6 +1143,10 @@ export class RecognizerProperty extends RecognitionClause {
     switch(this.operation){
       case RecognitionOp.PROPERTY_NE:
         return propertyValue != targetValue;
+      case RecognitionOp.PROPERTY_LT:
+        return propertyValue < targetValue;
+      case RecognitionOp.PROPERTY_GT:
+        return propertyValue > targetValue;
       case RecognitionOp.PROPERTY_EQ:
       default:
         return propertyValue == targetValue;

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -330,6 +330,7 @@ export class Dispatcher implements ZLUX.Dispatcher {
     if ((<ZLUX.RecognitionObjectOpClause>predicateObject).op) {
       const predicateOp: ZLUX.RecognitionObjectOpClause = <ZLUX.RecognitionObjectOpClause>predicateObject
       switch (predicateOp.op) {
+      case 'NOT':
       case 'AND':
       case 'OR':
         if (predicateOp.args) {
@@ -361,7 +362,7 @@ export class Dispatcher implements ZLUX.Dispatcher {
      this.recognizers.push(recognitionRule);
      if (predicate.operation == RecognitionOp.AND){
        for (let subClause of predicate.subClauses){
-         if ((subClause as RecognitionClause).operation == RecognitionOp.PROPERTY_EQ){
+         if ((subClause as RecognitionClause).operation == RecognitionOp.PROPERTY_EQ || (subClause as RecognitionClause).operation == RecognitionOp.NOT){
            let propertyClause:RecognitionClause = subClause as RecognitionClause;
            let propertyName:string = propertyClause.subClauses[0] as string;
            let propertyValue:string|number = propertyClause.subClauses[1] as string|number;
@@ -670,6 +671,7 @@ export class Dispatcher implements ZLUX.Dispatcher {
         if (!targetPluginID) {
           targetPluginID = actionAsAny.targetId;
         }
+        console.log("returning new action");
         return new Action(id, defaultName, targetMode, type, targetPluginID, primaryArgument);
     }
 
@@ -1099,6 +1101,18 @@ export class RecognizerOr extends RecognitionClause {
       }
     }
     return false;
+  }
+}
+
+export class RecognizerNot extends RecognitionClause {
+  constructor(propertyName:string, propertyValue:string|number){
+    super(RecognitionOp.NOT);
+    this.subClauses[0] = propertyName;
+    this.subClauses[1] = propertyValue;
+  }
+
+  match(applicationContext:any):boolean{
+    return applicationContext[this.subClauses[0] as string] != this.subClauses[1];
   }
 }
 

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -330,13 +330,6 @@ export class Dispatcher implements ZLUX.Dispatcher {
     if ((<ZLUX.RecognitionObjectOpClause>predicateObject).op) {
       const predicateOp: ZLUX.RecognitionObjectOpClause = <ZLUX.RecognitionObjectOpClause>predicateObject
       switch (predicateOp.op) {
-      case 'NOT':
-        if(predicateOp.args && predicateOp.args.length != 1){
-          const predicateProp: ZLUX.RecognitionObjectPropClause = <ZLUX.RecognitionObjectPropClause> (predicateOp.args as any)[0].prop;
-          return new RecognizerNot(predicateProp.prop[0],predicateProp.prop[1]);
-        } else {
-          throw new Error(`ZWED5020E - NOT is a unary recognizer op and only requires one arg.`);
-        }
       case 'AND':
       case 'OR':
         if (predicateOp.args) {

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -361,7 +361,7 @@ export class Dispatcher implements ZLUX.Dispatcher {
      this.recognizers.push(recognitionRule);
      if (predicate.operation == RecognitionOp.AND){
        for (let subClause of predicate.subClauses){
-        const operation = (subClause as RecognitionClause).operation;
+         const operation = (subClause as RecognitionClause).operation;
          if (operation === RecognitionOp.PROPERTY_EQ || operation === RecognitionOp.PROPERTY_NE){
            let propertyClause:RecognitionClause = subClause as RecognitionClause;
            let propertyName:string = propertyClause.subClauses[0] as string;

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -355,9 +355,13 @@ export class Dispatcher implements ZLUX.Dispatcher {
       default:
         throw new Error(`ZWED5021E - Recognizer predicate op ${predicateOp.op} not supported`);
       }
-    } else if ((<ZLUX.RecognitionObjectPropClause>predicateObject).prop && ((<ZLUX.RecognitionObjectPropClause>predicateObject).prop.length == 2)) {
+    } else if ((<ZLUX.RecognitionObjectPropClause>predicateObject).prop && ((<ZLUX.RecognitionObjectPropClause>predicateObject).prop.length >= 2)) {
       const predicateProp: ZLUX.RecognitionObjectPropClause = <ZLUX.RecognitionObjectPropClause> predicateObject;
-      return new RecognizerProperty(predicateProp.prop[0],predicateProp.prop[1]);
+      if ((<ZLUX.RecognitionObjectPropClause>predicateObject).prop.length == 2){
+        return new RecognizerProperty(predicateProp.prop[0],predicateProp.prop[1]);
+      } else {
+        return new RecognizerProperty(...predicateProp.prop);
+      }
     } else {
       throw new Error('ZWED5022E - Error in recognizer definition');
     }

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -1052,6 +1052,7 @@ export enum RecognitionOp {
   AND,
   OR,
   NOT,
+  NE,
   PROPERTY_EQ,        
   SOURCE_PLUGIN_TYPE,      // syntactic sugar
   MIME_TYPE,        // ditto
@@ -1122,7 +1123,7 @@ export class RecognizerProperty extends RecognitionClause {
   match(applicationContext:any):boolean{
     let propertyName, propertyValue;
     switch(this.operation){
-      case RecognitionOp.NOT:
+      case RecognitionOp.NE:
         propertyName = this.subClauses[1] as PropertyName;
         propertyValue = RecognizerProperty.getPropertyValue(applicationContext, propertyName);
         return propertyValue != this.subClauses[2];

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -362,7 +362,7 @@ export class Dispatcher implements ZLUX.Dispatcher {
      if (predicate.operation == RecognitionOp.AND){
        for (let subClause of predicate.subClauses){
          const operation = (subClause as RecognitionClause).operation;
-         if (operation === RecognitionOp.PROPERTY_EQ || operation === RecognitionOp.PROPERTY_NE){
+         if (operation === RecognitionOp.PROPERTY_EQ || operation === RecognitionOp.PROPERTY_NE || operation === RecognitionOp.PROPERTY_LT || operation === RecognitionOp.PROPERTY_GT){
            let propertyClause:RecognitionClause = subClause as RecognitionClause;
            let propertyName:string = propertyClause.subClauses[0] as string;
            let propertyValue:string|number = propertyClause.subClauses[1] as string|number;

--- a/base/src/dispatcher/recognizer.spec.ts
+++ b/base/src/dispatcher/recognizer.spec.ts
@@ -53,6 +53,78 @@ describe('Recognizer', () => {
       expect(property.match(context)).to.true;
     });
 
+    it(`should return true for greater than (type=number)`, () => {
+      const property = new RecognizerProperty('GT', 'a', 123);
+      const context = { a: 456 };
+      expect(property.match(context)).to.true;
+    });
+
+    it(`should return false for greater than (type=number)`, () => {
+      const property = new RecognizerProperty('GT', 'a', 456);
+      const context = { a: 123 };
+      expect(property.match(context)).to.false;
+    });
+
+    it(`should return true for less than (type=number)`, () => {
+      const property = new RecognizerProperty('LT', 'a', 456);
+      const context = { a: 123 };
+      expect(property.match(context)).to.true;
+    });
+
+    it(`should return false for less than (type=number)`, () => {
+      const property = new RecognizerProperty('LT', 'a', 123);
+      const context = { a: 456 };
+      expect(property.match(context)).to.false;
+    });
+
+    it(`should return true for greater than (type=string)`, () => {
+      const property = new RecognizerProperty('GT', 'a', "abc");
+      const context = { a: "cbc" };
+      expect(property.match(context)).to.true;
+    });
+
+    it(`should return false for greater than (type=string)`, () => {
+      const property = new RecognizerProperty('GT', 'a', "cbc");
+      const context = { a: "abc" };
+      expect(property.match(context)).to.false;
+    });
+
+    it(`should return true for less than (type=string)`, () => {
+      const property = new RecognizerProperty('LT', 'a', "cbc");
+      const context = { a: "abc" };
+      expect(property.match(context)).to.true;
+    });
+
+    it(`should return false for less than (type=string)`, () => {
+      const property = new RecognizerProperty('LT', 'a', "abc");
+      const context = { a: "cbc" };
+      expect(property.match(context)).to.false;
+    });
+
+    it(`should return true for greater than (type=string to number)`, () => {
+      const property = new RecognizerProperty('GT', 'a', "123");
+      const context = { a: 456 };
+      expect(property.match(context)).to.true;
+    });
+
+    it(`should return false for greater than (type=string to number)`, () => {
+      const property = new RecognizerProperty('GT', 'a', "456");
+      const context = { a: 123 };
+      expect(property.match(context)).to.false;
+    });
+
+    it(`should return true for less than (type=string to number)`, () => {
+      const property = new RecognizerProperty('LT', 'a', "456");
+      const context = { a: 123 };
+      expect(property.match(context)).to.true;
+    });
+
+    it(`should return false for less than (type=string to number)`, () => {
+      const property = new RecognizerProperty('LT', 'a', "123");
+      const context = { a: 456 };
+      expect(property.match(context)).to.false;
+    });
+
     it(`should not accept bad operator`, () => {
       const badRecognizerPropertyFn = () => new RecognizerProperty('BAD', 'a', 123);
       expect(badRecognizerPropertyFn).to.throw('ZWED5023E');

--- a/base/src/dispatcher/recognizer.spec.ts
+++ b/base/src/dispatcher/recognizer.spec.ts
@@ -46,6 +46,12 @@ describe('Recognizer', () => {
       const context = { a: 456 };
       expect(property.match(context)).to.false;
     });
+
+    it(`should return true for not equals`, () => {
+      const property = new RecognizerProperty('NOT', 'a', 123);
+      const context = { a: 456 };
+      expect(property.match(context)).to.true;
+    });
   });
 
   describe('Recognizer Properties using Dispatcher', () => {


### PR DESCRIPTION
This pull request implements the following feature:
- Implement 'not equal' recognition operator using the operator "NE"
- Implement 'less than' recognition operator using the operator "LT"
- Implement 'greater than' recognition operator using the operator "GT"
- [Allow nested properties in recognizers syntax](https://github.com/zowe/zlux-platform/pull/69) @lchudinov 
```
"recognizers":[
    {
      "id":"org.zowe.zlux.sample",
      "clause": {
        "op": "AND",
        "args": [
         {"prop":["NE","foo","bar"]},{"prop":["NE","foobar","barfoo"]}
        ]
      }
    }
  ]
```

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>