### PR TITLE
Add 'greater than/less than or equal to' recognizer operators

### DIFF
--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -364,7 +364,7 @@ export class Dispatcher implements ZLUX.Dispatcher {
          const operation = (subClause as RecognitionClause).operation;
          if (operation === RecognitionOp.PROPERTY_EQ || operation === RecognitionOp.PROPERTY_NE 
           || operation === RecognitionOp.PROPERTY_LT || operation === RecognitionOp.PROPERTY_GT
-          || operation === RecognitionOp.PROPERTY_LTE || operation === RecognitionOp.PROPERTY_GTE){
+          || operation === RecognitionOp.PROPERTY_LE || operation === RecognitionOp.PROPERTY_GE){
            let propertyClause:RecognitionClause = subClause as RecognitionClause;
            let propertyName:string = propertyClause.subClauses[0] as string;
            let propertyValue:string|number = propertyClause.subClauses[1] as string|number;
@@ -1059,8 +1059,8 @@ export enum RecognitionOp {
   PROPERTY_NE,
   PROPERTY_LT,
   PROPERTY_GT,
-  PROPERTY_LTE,
-  PROPERTY_GTE,
+  PROPERTY_LE,
+  PROPERTY_GE,
   SOURCE_PLUGIN_TYPE,      // syntactic sugar
   MIME_TYPE,        // ditto
 }
@@ -1127,10 +1127,10 @@ export class RecognizerProperty extends RecognitionClause {
             super(RecognitionOp.PROPERTY_GT);
             break;
           case 'LTE':
-            super(RecognitionOp.PROPERTY_LTE);
+            super(RecognitionOp.PROPERTY_LE);
             break;
           case 'GTE':
-            super(RecognitionOp.PROPERTY_GTE);
+            super(RecognitionOp.PROPERTY_GE);
             break;
           case 'EQ':
             super(RecognitionOp.PROPERTY_EQ);
@@ -1157,9 +1157,9 @@ export class RecognizerProperty extends RecognitionClause {
         return propertyValue < targetValue;
       case RecognitionOp.PROPERTY_GT:
         return propertyValue > targetValue;
-        case RecognitionOp.PROPERTY_LTE:
+        case RecognitionOp.PROPERTY_LE:
           return propertyValue <= targetValue;
-        case RecognitionOp.PROPERTY_GTE:
+        case RecognitionOp.PROPERTY_GE:
           return propertyValue >= targetValue;
       case RecognitionOp.PROPERTY_EQ:
       default:

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -362,7 +362,9 @@ export class Dispatcher implements ZLUX.Dispatcher {
      if (predicate.operation == RecognitionOp.AND){
        for (let subClause of predicate.subClauses){
          const operation = (subClause as RecognitionClause).operation;
-         if (operation === RecognitionOp.PROPERTY_EQ || operation === RecognitionOp.PROPERTY_NE || operation === RecognitionOp.PROPERTY_LT || operation === RecognitionOp.PROPERTY_GT){
+         if (operation === RecognitionOp.PROPERTY_EQ || operation === RecognitionOp.PROPERTY_NE 
+          || operation === RecognitionOp.PROPERTY_LT || operation === RecognitionOp.PROPERTY_GT
+          || operation === RecognitionOp.PROPERTY_LTE || operation === RecognitionOp.PROPERTY_GTE){
            let propertyClause:RecognitionClause = subClause as RecognitionClause;
            let propertyName:string = propertyClause.subClauses[0] as string;
            let propertyValue:string|number = propertyClause.subClauses[1] as string|number;
@@ -1056,7 +1058,9 @@ export enum RecognitionOp {
   PROPERTY_EQ,        
   PROPERTY_NE,
   PROPERTY_LT,
-  PROPERTY_GT ,
+  PROPERTY_GT,
+  PROPERTY_LTE,
+  PROPERTY_GTE,
   SOURCE_PLUGIN_TYPE,      // syntactic sugar
   MIME_TYPE,        // ditto
 }
@@ -1122,6 +1126,12 @@ export class RecognizerProperty extends RecognitionClause {
           case 'GT':
             super(RecognitionOp.PROPERTY_GT);
             break;
+          case 'LTE':
+            super(RecognitionOp.PROPERTY_LTE);
+            break;
+          case 'GTE':
+            super(RecognitionOp.PROPERTY_GTE);
+            break;
           case 'EQ':
             super(RecognitionOp.PROPERTY_EQ);
             break;
@@ -1147,6 +1157,10 @@ export class RecognizerProperty extends RecognitionClause {
         return propertyValue < targetValue;
       case RecognitionOp.PROPERTY_GT:
         return propertyValue > targetValue;
+        case RecognitionOp.PROPERTY_LTE:
+          return propertyValue <= targetValue;
+        case RecognitionOp.PROPERTY_GTE:
+          return propertyValue >= targetValue;
       case RecognitionOp.PROPERTY_EQ:
       default:
         return propertyValue == targetValue;

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -1126,10 +1126,10 @@ export class RecognizerProperty extends RecognitionClause {
           case 'GT':
             super(RecognitionOp.PROPERTY_GT);
             break;
-          case 'LTE':
+          case 'LE':
             super(RecognitionOp.PROPERTY_LE);
             break;
-          case 'GTE':
+          case 'GE':
             super(RecognitionOp.PROPERTY_GE);
             break;
           case 'EQ':

--- a/base/src/dispatcher/recognizer.spec.ts
+++ b/base/src/dispatcher/recognizer.spec.ts
@@ -125,6 +125,29 @@ describe('Recognizer', () => {
       expect(property.match(context)).to.false;
     });
 
+    it(`should return true for GTE (type=number)`, () => {
+      const property = new RecognizerProperty('GTE', 'a', 123);
+      const context = { a: 123 };
+      expect(property.match(context)).to.true;
+    });
+
+    it(`should return true for LTE (type=number)`, () => {
+      const property = new RecognizerProperty('LTE', 'a', 456);
+      const context = { a: 456 };
+      expect(property.match(context)).to.true;
+    });
+
+    it(`should return true for GTE (type=string)`, () => {
+      const property = new RecognizerProperty('GTE', 'a', "abb");
+      const context = { a: "abc" };
+      expect(property.match(context)).to.true;
+    });
+    it(`should return true for less than (type=string)`, () => {
+      const property = new RecognizerProperty('LTE', 'a', "abc");
+      const context = { a: "abb" };
+      expect(property.match(context)).to.true;
+    });
+
     it(`should not accept bad operator`, () => {
       const badRecognizerPropertyFn = () => new RecognizerProperty('BAD', 'a', 123);
       expect(badRecognizerPropertyFn).to.throw('ZWED5023E');

--- a/base/src/dispatcher/recognizer.spec.ts
+++ b/base/src/dispatcher/recognizer.spec.ts
@@ -125,25 +125,25 @@ describe('Recognizer', () => {
       expect(property.match(context)).to.false;
     });
 
-    it(`should return true for GTE (type=number)`, () => {
-      const property = new RecognizerProperty('GTE', 'a', 123);
+    it(`should return true for GE (type=number)`, () => {
+      const property = new RecognizerProperty('GE', 'a', 123);
       const context = { a: 123 };
       expect(property.match(context)).to.true;
     });
 
-    it(`should return true for LTE (type=number)`, () => {
-      const property = new RecognizerProperty('LTE', 'a', 456);
+    it(`should return true for LE (type=number)`, () => {
+      const property = new RecognizerProperty('LE', 'a', 456);
       const context = { a: 456 };
       expect(property.match(context)).to.true;
     });
 
-    it(`should return true for GTE (type=string)`, () => {
-      const property = new RecognizerProperty('GTE', 'a', "abb");
+    it(`should return true for GE (type=string)`, () => {
+      const property = new RecognizerProperty('GE', 'a', "abb");
       const context = { a: "abc" };
       expect(property.match(context)).to.true;
     });
-    it(`should return true for LTE (type=string)`, () => {
-      const property = new RecognizerProperty('LTE', 'a', "abc");
+    it(`should return true for LE (type=string)`, () => {
+      const property = new RecognizerProperty('LE', 'a', "abc");
       const context = { a: "abb" };
       expect(property.match(context)).to.true;
     });

--- a/base/src/dispatcher/recognizer.spec.ts
+++ b/base/src/dispatcher/recognizer.spec.ts
@@ -142,7 +142,7 @@ describe('Recognizer', () => {
       const context = { a: "abc" };
       expect(property.match(context)).to.true;
     });
-    it(`should return true for less than (type=string)`, () => {
+    it(`should return true for LTE (type=string)`, () => {
       const property = new RecognizerProperty('LTE', 'a', "abc");
       const context = { a: "abb" };
       expect(property.match(context)).to.true;


### PR DESCRIPTION
This pull request implements the following features:
- Add 'greater than/less than or equal to' recognizer operators
- Update unit test

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>