### PR TITLE
Fix for registering actions twice inside ActionContainer

### DIFF
--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -443,7 +443,7 @@ export class Dispatcher implements ZLUX.Dispatcher {
           }
         }
       }
-    }  
+    }
   }
 
   /**

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -432,18 +432,6 @@ export class Dispatcher implements ZLUX.Dispatcher {
     }
 
     this.actionsByID.set(action.id, action);
-
-    if (action instanceof ActionContainer) {
-      const { children } = action as ActionContainer;
-
-      if (children && children.length > 0) {
-        for (let child of children) {
-          if (child instanceof AbstractAction) {
-            this.registerAbstractAction(child);
-          }
-        }
-      }
-    }
   }
 
   /**

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -434,15 +434,15 @@ export class Dispatcher implements ZLUX.Dispatcher {
     this.actionsByID.set(action.id, action);
 
     if (action instanceof ActionContainer) {
-      const { children } = action as ActionContainer;  
+      const { children } = action as ActionContainer;
 
-        if (children && children.length > 0) {
-          for (let child of children) {
-            if (child instanceof AbstractAction) {
-              this.registerAbstractAction(child);
-            }
+      if (children && children.length > 0) {
+        for (let child of children) {
+          if (child instanceof AbstractAction) {
+            this.registerAbstractAction(child);
           }
         }
+      }
     }  
   }
 

--- a/base/src/dispatcher/dispatcher.ts
+++ b/base/src/dispatcher/dispatcher.ts
@@ -432,6 +432,18 @@ export class Dispatcher implements ZLUX.Dispatcher {
     }
 
     this.actionsByID.set(action.id, action);
+
+    if (action instanceof ActionContainer) {
+      const { children } = action as ActionContainer;  
+
+        if (children && children.length > 0) {
+          for (let child of children) {
+            if (child instanceof AbstractAction) {
+              this.registerAbstractAction(child);
+            }
+          }
+        }
+    }  
   }
 
   /**
@@ -642,7 +654,6 @@ export class Dispatcher implements ZLUX.Dispatcher {
               child = childIn as ZLUX.ActionReference;
             } else {
               child = this.makeActionFromObject(childIn as ZLUX.AbstractAction);
-              this.registerAbstractAction(child as ZLUX.AbstractAction);
             }
             children.push(child);
           }


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
ActionContainer's children were previously registered in both `makeActionFromObject` and `registerAbstractAction` methods. Though it did not affect anything, it gave messages in the console about duplicate action-id. Now the ActionContainer's children are registered just once in `registerAbstractAction` method and not in `makeActionFromObject`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->

