### PR TITLE
Add v2 plugin definition

### DIFF
--- a/base/src/plugin-manager/plugin.ts
+++ b/base/src/plugin-manager/plugin.ts
@@ -43,6 +43,8 @@ export abstract class Plugin implements ZLUX.Plugin {
         return new Plugin_0(definition);
       case 1:
         return new Plugin_1(definition);
+      case 2:
+        return new Plugin_2(definition);
       default:
         throw new Error("ZWED5038E - Unrecognized plugin definition major version");
     }
@@ -164,6 +166,13 @@ class Plugin_1 extends Plugin_0 {
 
 }
 
+class Plugin_2 extends Plugin_1 {
+  constructor(definition: any) {
+    super(definition);
+  }
+
+}
+
 
 /*
   This program and the accompanying materials are
@@ -174,4 +183,3 @@ class Plugin_1 extends Plugin_0 {
   
   Copyright Contributors to the Zowe Project.
 */
-


### PR DESCRIPTION
## Proposed changes
This is one of several PRs which do some finishing touches on v2 documentation, componentization, metadata, and changelogs. Plugins have had their api version changed to 2.0.0 to show that they are intended for v2 of the desktop not v1, changelogs note breaking changes as I know them, and readmes have been updated to point to the docs, schemas, and notably not the wiki since its no longer where developer info goes (instead, zowe docs site extended section)

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] Change in a documentation
- [x] Chore, repository cleanup, updates the dependencies.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
I am making a test build. The main things to check for are
1) Does the desktop load the same as before? Changing the plugins to api=2 would break without an update to the platform, so check that plugins load fine
2) Can you install the sample apps with zwe components install?