### PR TITLE
Exclude wrong version of angular plugins by checking entrypoint content

### DIFF
--- a/base/src/plugin-manager/plugin-manager.ts
+++ b/base/src/plugin-manager/plugin-manager.ts
@@ -64,7 +64,7 @@ export class PluginManager {
                 var result = JSON.parse(this.responseText);
                 let allPlugins = PluginManager.parsePluginDefinitions(result);
                 const searchParams = new URLSearchParams(window.location.search);
-                const useV2Desktop = searchParams.has("use-v2-desktop") && (searchParams.get("use-v2-desktop") == '1');
+                const useV2Desktop = searchParams.has("use-v2-desktop") && (searchParams.get("use-v2-desktop") == 'true');
                 let validPlugins = allPlugins.filter((plugin) => {
                   if (plugin.type != 'application') {
                     return true;
@@ -74,9 +74,9 @@ export class PluginManager {
                       return true;
                     } else {
                       //exclude apps incompatible with the given desktop environment, depending upon their entryPoint content.
-                      if (useV2Desktop && (!webContent.entryPoint || webContent.entryPoint.v2)) {
+                      if (useV2Desktop && (!webContent.entryPoint || webContent.entryPoint['2.0'])) {
                         return true;
-                      } else if (!useV2Desktop && webContent.entryPoint && webContent.entryPoint.v3) {
+                      } else if (!useV2Desktop && webContent.entryPoint && webContent.entryPoint['3.0']) {
                         return true;
                       } else {
                         return false;

--- a/base/src/plugin-manager/plugin-manager.ts
+++ b/base/src/plugin-manager/plugin-manager.ts
@@ -70,7 +70,9 @@ export class PluginManager {
                     return true;
                   } else {
                     const webContent = plugin.getWebContent();
-                    if (webContent.framework != 'angular') {
+                    if (!webContent) {
+                      return true;
+                    } else if ((webContent.framework != 'angular') && (webContent.framework != 'angular2')) {
                       return true;
                     } else {
                       //exclude apps incompatible with the given desktop environment, depending upon their entryPoint content.

--- a/base/src/plugin-manager/plugin-manager.ts
+++ b/base/src/plugin-manager/plugin-manager.ts
@@ -63,10 +63,31 @@ export class PluginManager {
               try {
                 var result = JSON.parse(this.responseText);
                 let allPlugins = PluginManager.parsePluginDefinitions(result);
+                const searchParams = new URLSearchParams(window.location.search);
+                const useV2Desktop = searchParams.has("use-v2-desktop") && (searchParams.get("use-v2-desktop") == '1');
+                let validPlugins = allPlugins.filter((plugin) => {
+                  if (plugin.type != 'application') {
+                    return true;
+                  } else {
+                    const webContent = plugin.getWebContent();
+                    if (webContent.framework != 'angular') {
+                      return true;
+                    } else {
+                      //exclude apps incompatible with the given desktop environment, depending upon their entryPoint content.
+                      if (useV2Desktop && (!webContent.entryPoint || webContent.entryPoint.v2)) {
+                        return true;
+                      } else if (!useV2Desktop && webContent.entryPoint && webContent.entryPoint.v3) {
+                        return true;
+                      } else {
+                        return false;
+                      }
+                    }
+                  }
+                });
                 if (!pluginType) {
-                  resolve(allPlugins);
+                  resolve(validPlugins);
                 } else {
-                  const filtered = allPlugins.filter(plugin => plugin.getType() == pluginType)
+                  const filtered = validPlugins.filter(plugin => plugin.getType() == pluginType)
                   resolve(filtered);
                 }
               } catch (error) {

--- a/base/src/plugin-manager/plugin.ts
+++ b/base/src/plugin-manager/plugin.ts
@@ -171,6 +171,22 @@ class Plugin_2 extends Plugin_1 {
     super(definition);
   }
 
+  getWebEntrypoint():string|undefined {
+    let entryPoints = this.webContent?.entryPoints;
+    if (entryPoints) {
+      const searchParams = new URLSearchParams(window.location.search);
+      const useV2Desktop = searchParams.has("use-v2-desktop") && (searchParams.get("use-v2-desktop") == '1');
+      if (useV2Desktop || !entryPoints['3.0']) {
+        return 'main.js';
+      } else {
+        return ''+entryPoints['3.0'];
+      }
+    } else if (this.webContent) {
+      return 'main.js';
+    }
+    return undefined;
+  }
+
 }
 
 

--- a/base/src/plugin-manager/plugin.ts
+++ b/base/src/plugin-manager/plugin.ts
@@ -172,14 +172,14 @@ class Plugin_2 extends Plugin_1 {
   }
 
   getWebEntrypoint():string|undefined {
-    let entryPoints = this.webContent?.entryPoints;
-    if (entryPoints) {
+    let entryPoint = this.webContent?.entryPoint;
+    if (entryPoint) {
       const searchParams = new URLSearchParams(window.location.search);
-      const useV2Desktop = searchParams.has("use-v2-desktop") && (searchParams.get("use-v2-desktop") == '1');
-      if (useV2Desktop || !entryPoints['3.0']) {
+      const useV2Desktop = searchParams.has("use-v2-desktop") && (searchParams.get("use-v2-desktop") == 'true');
+      if (useV2Desktop || !entryPoint['3.0']) {
         return 'main.js';
       } else {
-        return ''+entryPoints['3.0'];
+        return ''+entryPoint['3.0'];
       }
     } else if (this.webContent) {
       return 'main.js';

--- a/interface/src/index.d.ts
+++ b/interface/src/index.d.ts
@@ -299,6 +299,10 @@ declare namespace ZLUX {
     getBasePlugin(): any;
   }
 
+  interface PluginV2 extends Plugin {
+    getWebEntryPoint():string|undefined;
+  }
+
   interface ContainerPluginDefinition {
     getBasePlugin():Plugin;
   }


### PR DESCRIPTION
According to https://github.com/zowe/zlux-app-server/pull/308 you can state what the location of your primary JS file is for loading.
Angular in particular uses this, and we need it to determine whether an installed plugin is appropriate for the desktop that is being loaded (which is detected by query parameters like ?use-v2-desktop=1)

This should be tested by having an angular plugin which does not use the new features of PR 308, having another which does, and testing with/without "?use-v2-desktop=1" in the URL of the desktop.
You should see that depending upon whether a plugin has or does not have v2 or v3 angular content, it will be permitted or omitted from visibility in the desktop.