### PR TITLE
Fix bug where filtering of old angular plugins occurred in wrong section

### DIFF
--- a/base/src/plugin-manager/plugin-manager.ts
+++ b/base/src/plugin-manager/plugin-manager.ts
@@ -36,8 +36,33 @@ export class PluginManager {
         }
       });
 
-      /* Remove skipped plugins */
-      return plugins.filter(x => x) as Plugin[];
+      /* Remove skipped plugins and apps not valid for this version*/
+      let filtered =  plugins.filter(x => x) as Plugin[];
+      const searchParams = new URLSearchParams(window.location.search);
+      const useV2Desktop = searchParams.has("use-v2-desktop") && (searchParams.get("use-v2-desktop") == 'true');
+      return filtered.filter((plugin) => {
+        if (plugin.type != 'application') {
+          return true;
+        } else {
+          const webContent = plugin.webContent;
+          if (!webContent) {
+            return true;
+          } else if ((webContent.framework != 'angular') && (webContent.framework != 'angular2')) {
+            return true;
+          } else {
+            //exclude apps incompatible with the given desktop environment, depending upon their entryPoint content.
+            if (useV2Desktop && (!webContent.entryPoint || webContent.entryPoint['2.0'])) {
+              return true;
+            } else if (!useV2Desktop && webContent.entryPoint && webContent.entryPoint['3.0']) {
+              return true;
+            } else {
+              this.pluginsById.delete(plugin.identifier);
+              return false;
+            }
+          }
+        }
+      });
+
     } else {
       throw new Error("ZWED5037E - Unable to parse plugin definitions: Missing field 'pluginDefinitions'");
     }
@@ -62,30 +87,7 @@ export class PluginManager {
             case 304:
               try {
                 var result = JSON.parse(this.responseText);
-                let allPlugins = PluginManager.parsePluginDefinitions(result);
-                const searchParams = new URLSearchParams(window.location.search);
-                const useV2Desktop = searchParams.has("use-v2-desktop") && (searchParams.get("use-v2-desktop") == 'true');
-                let validPlugins = allPlugins.filter((plugin) => {
-                  if (plugin.type != 'application') {
-                    return true;
-                  } else {
-                    const webContent = plugin.getWebContent();
-                    if (!webContent) {
-                      return true;
-                    } else if ((webContent.framework != 'angular') && (webContent.framework != 'angular2')) {
-                      return true;
-                    } else {
-                      //exclude apps incompatible with the given desktop environment, depending upon their entryPoint content.
-                      if (useV2Desktop && (!webContent.entryPoint || webContent.entryPoint['2.0'])) {
-                        return true;
-                      } else if (!useV2Desktop && webContent.entryPoint && webContent.entryPoint['3.0']) {
-                        return true;
-                      } else {
-                        return false;
-                      }
-                    }
-                  }
-                });
+                let validPlugins = PluginManager.parsePluginDefinitions(result);
                 if (!pluginType) {
                   resolve(validPlugins);
                 } else {


### PR DESCRIPTION
plugin-manager had code to filter plugins that wont work on the v3 desktop so that they dont show up as a choice in the v3 desktop.
unfortunately, that filter code was in the wrong place.
some code upstream in zlux-app-manager directly uses "pluginManager.pluginsById" and the filtering in loadPlugins() did not cover that.
Instead, the filtering should occur within parsePluginDefinitions() as it is used by both that function and directly sets "pluginManager.pluginsById".

In the filter now, angular plugins that are not clearly marked as v3 compatible will be excluded from "pluginManager.pluginsById", and then will not show up in the desktop as a result, as intended.