### PR TITLE
Set specific versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.0.0-zlux.version.replacement",
       "license": "private",
       "devDependencies": {
-        "@types/chai": "~4.2.14",
-        "@types/express": "~4.16.1",
-        "@types/mocha": "~8.2.0",
-        "@types/node": "~14.14.22",
-        "chai": "~4.2.0",
-        "mocha": "~10.2.0",
-        "rxjs": "~6.6.0",
-        "ts-mocha": "~10.0.0",
-        "typescript": "~4.2.0"
+        "@types/chai": "4.2.18",
+        "@types/express": "4.16.1",
+        "@types/mocha": "8.2.2",
+        "@types/node": "14.14.45",
+        "chai": "4.2.0",
+        "mocha": "10.2.0",
+        "rxjs": "6.6.7",
+        "ts-mocha": "10.0.0",
+        "typescript": "4.2.4"
       }
     },
     "node_modules/@types/body-parser": {

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
   "keywords": [],
   "author": "",
   "devDependencies": {
-    "@types/chai": "~4.2.14",
-    "@types/express": "~4.16.1",
-    "@types/mocha": "~8.2.0",
-    "@types/node": "~14.14.22",
-    "chai": "~4.2.0",
-    "mocha": "~10.2.0",
-    "rxjs": "~6.6.0",
-    "ts-mocha": "~10.0.0",
-    "typescript": "~4.2.0"
+    "@types/chai": "4.2.18",
+    "@types/express": "4.16.1",
+    "@types/mocha": "8.2.2",
+    "@types/node": "14.14.45",
+    "chai": "4.2.0",
+    "mocha": "10.2.0",
+    "rxjs": "6.6.7",
+    "ts-mocha": "10.0.0",
+    "typescript": "4.2.4"
   }
 }


### PR DESCRIPTION
This PR sets all package.json versions to what was found in package-lock.json to set a baseline for specific versions rather than relying on version ranges.