### PR TITLE
Add Interface and Toaken for Apps to Register as Search Providers

### DIFF
--- a/interface/src/mvd-hosting.d.ts
+++ b/interface/src/mvd-hosting.d.ts
@@ -20,7 +20,7 @@ declare namespace MVDHosting {
     PluginManagerToken = "com.rs.mvd.hosting.plugin-manager",
     AuthenticationManagerToken = "com.rs.mvd.hosting.authentication-manager",
     ThemeEmitterToken = "com.rs.mvd.hosting.theme-emitter",
-    SpotlightSearchToken = "com.rs.mvd.hosting.spotlight-search"
+    QuickSearchToken = "com.rs.mvd.hosting.quick-search"
   }
 
   export const enum ZoweNotificationType {
@@ -123,17 +123,17 @@ declare namespace MVDHosting {
     handleMessageRemoved(id: number): void;
   }
 
-  export interface SpotlightSearchInterface {
-    registerProvider(provider: SpotlightProviderInterface): void;
+  export interface QuickSearchInterface {
+    registerProvider(provider: QuickSearchProviderInterface): void;
     unregisterProvider(id: string): void;
-    getProvider(id: string): SpotlightProviderInterface | undefined;
-    getProviderForCategory(category: string): SpotlightProviderInterface | undefined;
-    getProviders(): SpotlightProviderInterface[];
+    getProvider(id: string): QuickSearchProviderInterface | undefined;
+    getProviderForCategory(category: string): QuickSearchProviderInterface | undefined;
+    getProviders(): QuickSearchProviderInterface[];
     getCategoryIcon(category: string): string;
     getCategoryOrder(): string[];
   }
 
-  export interface SpotlightProviderInterface {
+  export interface QuickSearchProviderInterface {
     id: string;
     category: string;
     icon: string;

--- a/interface/src/mvd-hosting.d.ts
+++ b/interface/src/mvd-hosting.d.ts
@@ -123,6 +123,27 @@ declare namespace MVDHosting {
     handleMessageRemoved(id: number): void;
   }
 
+  export interface QuickSearchResultInterface {
+    category: string;
+    label: string;
+    description?: string;
+    icon?: string;
+    output?: string;
+    pendingExecution?: boolean;
+    historyItem?: boolean;
+    historyCommand?: string;
+    action: () => void;
+    actionMetadata?: {
+      type: string;
+      targetPluginId?: string;
+      data?: any;
+      path?: string;
+      text?: string;
+    };
+    execute?: () => Observable<QuickSearchResultInterface[]>;
+    providerId?: string;
+  }
+
   export interface QuickSearchInterface {
     registerProvider(provider: QuickSearchProviderInterface): void;
     unregisterProvider(id: string): void;
@@ -131,6 +152,11 @@ declare namespace MVDHosting {
     getProviders(): QuickSearchProviderInterface[];
     getCategoryIcon(category: string): string;
     getCategoryOrder(): string[];
+    isBareCommandPrefix(query: string): boolean;
+    search(query: string): Observable<QuickSearchResultInterface[]>;
+    setVisible(visible: boolean): void;
+    isVisible(): boolean;
+    removeHistoryItem(category: string, cmd: string): void;
   }
 
   export interface QuickSearchProviderInterface {
@@ -140,8 +166,8 @@ declare namespace MVDHosting {
     prefixes: string[];
     order: number;
     canSearch(query: string): boolean;
-    search(query: string): Observable<any>;
-    getHistory?(): any[];
+    search(query: string): Observable<QuickSearchResultInterface[]>;
+    getHistory?(): QuickSearchResultInterface[];
     clearHistory?(): void;
     removeHistoryItem?(cmd: string): void;
     suppressNoResults?: boolean;

--- a/interface/src/mvd-hosting.d.ts
+++ b/interface/src/mvd-hosting.d.ts
@@ -19,7 +19,8 @@ declare namespace MVDHosting {
     ViewportManagerToken = "com.rs.mvd.hosting.viewport-manager",
     PluginManagerToken = "com.rs.mvd.hosting.plugin-manager",
     AuthenticationManagerToken = "com.rs.mvd.hosting.authentication-manager",
-    ThemeEmitterToken = "com.rs.mvd.hosting.theme-emitter"
+    ThemeEmitterToken = "com.rs.mvd.hosting.theme-emitter",
+    SpotlightSearchToken = "com.rs.mvd.hosting.spotlight-search"
   }
 
   export const enum ZoweNotificationType {
@@ -120,6 +121,30 @@ declare namespace MVDHosting {
   export interface ZoweNotificationWatcher {
     handleMessageAdded(test: any): void;
     handleMessageRemoved(id: number): void;
+  }
+
+  export interface SpotlightSearchInterface {
+    registerProvider(provider: SpotlightProviderInterface): void;
+    unregisterProvider(id: string): void;
+    getProvider(id: string): SpotlightProviderInterface | undefined;
+    getProviderForCategory(category: string): SpotlightProviderInterface | undefined;
+    getProviders(): SpotlightProviderInterface[];
+    getCategoryIcon(category: string): string;
+    getCategoryOrder(): string[];
+  }
+
+  export interface SpotlightProviderInterface {
+    id: string;
+    category: string;
+    icon: string;
+    prefixes: string[];
+    order: number;
+    canSearch(query: string): boolean;
+    search(query: string): Observable<any>;
+    getHistory?(): any[];
+    clearHistory?(): void;
+    removeHistoryItem?(cmd: string): void;
+    suppressNoResults?: boolean;
   }
 }
 


### PR DESCRIPTION
## Proposed changes

Adds the `MVDHosting` type declarations needed for the Zowe Desktop Quick Launcher (Spotlight) provider registry. This allows ZLUX plugins to register custom search categories with the Spotlight launcher by injecting the `SpotlightSearchService` via `MVDHosting.Tokens.SpotlightSearchToken`.

This PR depends upon the following PRs:
- https://github.com/zowe/zlux-app-manager/pull/723

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Testing

This PR only adds TypeScript type declarations (`.d.ts`). No runtime behavior is introduced here -- the implementation lives in zlux-app-manager PR #723.

To verify:
1. Check out zlux-app-manager `feature/quickLauncher` alongside this branch
2. Build virtual-desktop (`cd zlux-app-manager/virtual-desktop && npm run build`) -- confirms the token and interface declarations are compatible with the concrete `SpotlightSearchService`
3. A plugin can inject the service via `this.injector.get(MVDHosting.Tokens.SpotlightSearchToken)` and call `registerProvider()` / `unregisterProvider()` to add custom Spotlight search categories

## Further comments

**What is added:**

- `MVDHosting.Tokens.SpotlightSearchToken` -- injection token so plugins can access the Spotlight search service from the desktop's injector
- `MVDHosting.SpotlightSearchInterface` -- the public API surface for registering/unregistering providers and querying provider metadata
- `MVDHosting.SpotlightProviderInterface` -- the contract a plugin implements to define a custom search category (id, category name, icon, slash-prefixes, search method, optional history)

These declarations follow the existing pattern used by `ApplicationManagerToken`/`ApplicationManagerInterface`, `PluginManagerToken`/`PluginManagerInterface`, etc.