### PR TITLE
Add env value for zss host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Zlux Platform Changelog
+
+All notable changes to the Zlux Platform package will be documented in this file.
+This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
+
+## 3.6.0
+- Enhancement: Added `host?: string` to the `ZLUX.AgentConfig` interface, exposing the ZSS/agent hostname alongside the existing `mediationLayer` property.
+- Enhancement: Added `getAgentHost(): Promise<string|undefined>` to the `ZLUX.Environment` interface and its `Environment` implementation. Reads `agent.host` from the cached `/server/environment` response, allowing any plugin to retrieve the agent hostname via `ZoweZLUX.environment.getAgentHost()` without making an additional HTTP request.

--- a/base/src/dispatcher/recognizer.spec.ts
+++ b/base/src/dispatcher/recognizer.spec.ts
@@ -166,11 +166,11 @@ describe('Recognizer', () => {
     const nop = () => { };
 
     beforeEach(() => {
-      const mockupLogger = <ZLUX.ComponentLogger>{
+      const mockupLogger = {
         debug: nop,
         warn: nop,
         info: nop,
-      };
+      } as ZLUX.ComponentLogger;
       dispatcher = new Dispatcher(mockupLogger);
 
       const actionTitle = 'test action';

--- a/base/src/environment/environment.ts
+++ b/base/src/environment/environment.ts
@@ -134,6 +134,14 @@ export class Environment implements ZLUX.Environment {
     });
   }
 
+  getAgentHost(): Promise<string|undefined> {
+    return new Promise((resolve, reject)=> {
+      this._queryServer().then(function (cache:EnvironmentResponse){
+        resolve(cache.agent?.host);
+      }).catch((err)=>{reject(err);});
+    });
+  }
+
   getChangePasswordEnableFlag(): Promise<boolean> {
     return new Promise((resolve, reject)=> {
       this._queryServer().then(function (cache:EnvironmentResponse){

--- a/interface/src/index.d.ts
+++ b/interface/src/index.d.ts
@@ -168,6 +168,7 @@ declare namespace ZLUX {
   }
 
   interface AgentConfig {
+    host?: string;
     mediationLayer?: AgentAPIMLConfig;
   }
 
@@ -178,6 +179,7 @@ declare namespace ZLUX {
     getExternalComponents(): Promise<string[]|undefined>;
     getGatewayPort(): Promise<number|undefined>;
     getGatewayHost(): Promise<string|undefined>;
+    getAgentHost(): Promise<string|undefined>;
     getPlatform(): Promise<string>;
     getAgentConfig(): Promise<AgentConfig|undefined>;
     getArch(): Promise<string>;


### PR DESCRIPTION
## Proposed changes

Extends the `ZLUX.Environment` interface and its `Environment` implementation to expose the agent (ZSS) hostname through a new `getAgentHost()` method.

Previously, there was no typed API for retrieving the ZSS/agent hostname from the environment. Terminal plugins worked around this by calling the now-removed `/server/proxies` endpoint directly. This PR introduces the proper API surface so that any plugin can retrieve the agent host through the standard `ZoweZLUX.environment` object.

Changes:
- `ZLUX.AgentConfig` interface gains an optional `host?: string` property, consistent with the existing `mediationLayer` property. This means `getAgentConfig()` also exposes the host.
- `ZLUX.Environment` interface gains `getAgentHost(): Promise<string|undefined>`, placed alongside the existing `getGatewayHost()` method.
- The `Environment` class implementation adds the corresponding `getAgentHost()` method, which reads `cache.agent?.host` from the cached `/server/environment` response (populated by a companion PR to zlux-server-framework).

This PR addresses Issue: N/A

This PR depends upon the following PRs: N/A

**Files changed:**
- `interface/src/index.d.ts` — added `host?: string` to `AgentConfig`; added `getAgentHost()` to `Environment` interface
- `base/src/environment/environment.ts` — added `getAgentHost()` implementation

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## PR Checklist

- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [ ] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

1. Build zlux-platform and ensure no TypeScript compilation errors.
2. In a browser console within the Zowe Desktop, call `ZoweZLUX.environment.getAgentHost()` and confirm it resolves to the expected ZSS hostname.
3. Confirm `ZoweZLUX.environment.getAgentConfig()` also returns an object with the `host` field populated.
4. Confirm `ZoweZLUX.environment.getGatewayHost()` is unaffected.

## Further comments

`getAgentHost()` follows the same implementation pattern as `getGatewayHost()`: it calls `_queryServer()` (with caching) and reads a field from the cached response object. The value is populated server-side in the companion zlux-server-framework PR.
